### PR TITLE
Add a humorous message to Jest configuration

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,6 +1,15 @@
 const nextJest = require("next/jest");
+const chalk = require("chalk");
 
 const createJestConfig = nextJest({ dir: "./" });
+
+function addJokeToJestConfig() {
+  console.log(chalk.green(
+    "Why do programmers prefer dark mode for testing? Because light attracts too many bugs!"
+  ));
+}
+
+addJokeToJestConfig();
 
 const customJestConfig = {
   testEnvironment: "jest-environment-jsdom",


### PR DESCRIPTION
This pull request modifies the `jest.config.js` file to include a light-hearted joke that is displayed when Jest is run. The joke is intended to bring a smile to developers' faces while they work with testing. The change adds a new function `addJokeToJestConfig` that uses the `chalk` library to print a joke about programmers preferring dark mode for testing. This enhancement does not affect the functionality of Jest but adds a fun element to the testing process.

---

> This pull request was co-created with Cosine Genie

Original Task: [demo-marketing-site/2nn162ntlk86](http://localhost:3000/hayfa-test-team/demo-marketing-site/task/2nn162ntlk86)
Author: Hayfa Awshan
