### PR TITLE
Enhance Jest Configuration for Asset Mocking

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -6,6 +6,10 @@ const customJestConfig = {
   testEnvironment: "jest-environment-jsdom",
   setupFilesAfterEnv: ["<rootDir>/jest.setup.js"],
   moduleDirectories: ["node_modules", "<rootDir>/"],
+  moduleNameMapper: {
+    "^.+\\.(css|less|scss|sass)$": "identity-obj-proxy",
+    "^.+\\.(jpg|jpeg|png|gif|webp|svg)$": "<rootDir>/__mocks__/fileMock.js"
+  },
 };
 
 module.exports = createJestConfig(customJestConfig);


### PR DESCRIPTION
This pull request modifies the Jest configuration to include module name mappings for styles and image files. Specifically, it adds support for mocking CSS and image files using `identity-obj-proxy` and a custom file mock, respectively. This change will help streamline testing by preventing errors related to importing these asset types.

---

> This pull request was co-created with Cosine Genie

Original Task: [demo-marketing-site/m8ou7q57zahc](http://localhost:3000/hayfa-test-team/demo-marketing-site/task/m8ou7q57zahc)
Author: Hayfa Awshan
