### PR TITLE
Enhance Jest Configuration for TypeScript Module Resolution

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,4 +1,6 @@
 const nextJest = require("next/jest");
+const { pathsToModuleNameMapper } = require("ts-jest");
+const { compilerOptions } = require("./tsconfig.json");
 
 const createJestConfig = nextJest({ dir: "./" });
 
@@ -6,6 +8,7 @@ const customJestConfig = {
   testEnvironment: "jest-environment-jsdom",
   setupFilesAfterEnv: ["<rootDir>/jest.setup.js"],
   moduleDirectories: ["node_modules", "<rootDir>/"],
+  moduleNameMapper: pathsToModuleNameMapper(compilerOptions.paths, { prefix: "<rootDir>/" }),
 };
 
 module.exports = createJestConfig(customJestConfig);


### PR DESCRIPTION
This pull request modifies the Jest configuration to improve TypeScript module resolution. It adds the `moduleNameMapper` property using `pathsToModuleNameMapper` from `ts-jest`, which maps the paths defined in `tsconfig.json` to the Jest environment. This change ensures that Jest can correctly resolve modules during testing, aligning with the TypeScript configuration and enhancing the testing experience.

---

> This pull request was co-created with Cosine Genie

Original Task: [demo-marketing-site/knkmfgzvxbcq](http://localhost:3000/hayfa-test-team/demo-marketing-site/task/knkmfgzvxbcq)
Author: Hayfa Awshan
