### PR TITLE
Add tests for useIsMobile hook

### DIFF
--- a/__tests__/useIsMobile.test.tsx
+++ b/__tests__/useIsMobile.test.tsx
@@ -1,0 +1,96 @@
+import { render, screen, act } from "@testing-library/react";
+import { useIsMobile } from "../hooks/use-mobile";
+import "@testing-library/jest-dom/extend-expect";
+import '@testing-library/jest-dom';
+import * as React from "react";
+
+const MOBILE_BREAKPOINT = 768;
+
+// Helper function to simulate window resize
+const resizeWindow = (width: number) => {
+  Object.defineProperty(window, 'innerWidth', { writable: true, configurable: true, value: width });
+  window.dispatchEvent(new Event('resize'));
+  const mql = { matches: width < MOBILE_BREAKPOINT, addEventListener: jest.fn(), removeEventListener: jest.fn() };
+  jest.spyOn(window, 'matchMedia').mockImplementation(() => mql as any);
+  const event = new Event('change');
+  mql.addEventListener.mock.calls[0][1](event);
+};
+
+// Test component that uses the hook
+const TestComponent = () => {
+  const isMobile = useIsMobile();
+  return (
+    <div data-testid="mobile-status">
+      {isMobile ? "Mobile View" : "Desktop View"}
+    </div>
+  );
+};
+
+describe("useIsMobile Hook", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.spyOn(window, 'matchMedia').mockImplementation(() => ({
+      matches: false,
+      addEventListener: jest.fn(),
+      removeEventListener: jest.fn()
+    } as any));
+  });
+
+  test("returns true when viewport width is below mobile breakpoint", () => {
+    render(<TestComponent />);
+    
+    // Simulate mobile viewport
+    act(() => {
+      resizeWindow(MOBILE_BREAKPOINT - 1);
+    });
+    
+    expect(screen.getByTestId("mobile-status")).toHaveTextContent("Mobile View");
+  });
+
+  test("returns false when viewport width is above mobile breakpoint", () => {
+    render(<TestComponent />);
+    
+    // Simulate desktop viewport
+    act(() => {
+      resizeWindow(MOBILE_BREAKPOINT + 1);
+    });
+    
+    expect(screen.getByTestId("mobile-status")).toHaveTextContent("Desktop View");
+  });
+
+  test("updates when viewport changes size", () => {
+    render(<TestComponent />);
+    
+    // Start with desktop viewport
+    act(() => {
+      resizeWindow(MOBILE_BREAKPOINT + 100);
+    });
+    expect(screen.getByTestId("mobile-status")).toHaveTextContent("Desktop View");
+    
+    // Change to mobile viewport
+    act(() => {
+      resizeWindow(MOBILE_BREAKPOINT - 100);
+    });
+    expect(screen.getByTestId("mobile-status")).toHaveTextContent("Mobile View");
+    
+    // Back to desktop
+    act(() => {
+      resizeWindow(MOBILE_BREAKPOINT + 1);
+    });
+    expect(screen.getByTestId("mobile-status")).toHaveTextContent("Desktop View");
+  });
+
+  test("cleans up event listeners on unmount", () => {
+    const removeEventListenerMock = jest.fn();
+    jest.spyOn(window, 'matchMedia').mockImplementation(() => ({
+      matches: false,
+      addEventListener: jest.fn(),
+      removeEventListener: removeEventListenerMock
+    } as any));
+    
+    const { unmount } = render(<TestComponent />);
+    unmount();
+    
+    expect(removeEventListenerMock).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
This pull request introduces a new test suite for the `useIsMobile` hook, ensuring its functionality across different viewport sizes. The tests cover the following scenarios:

1. **Mobile View**: Verifies that the hook returns true when the viewport width is below the defined mobile breakpoint (768px).
2. **Desktop View**: Checks that the hook returns false when the viewport width is above the mobile breakpoint.
3. **Viewport Change**: Confirms that the hook updates correctly when the viewport size changes.
4. **Cleanup on Unmount**: Ensures that event listeners are properly cleaned up when the component using the hook unmounts.

These tests help maintain the reliability of the `useIsMobile` hook and ensure it behaves as expected in different scenarios.

---

> This pull request was co-created with Cosine Genie

Original Task: [demo-marketing-site/m0fpt8ios36a](http://localhost:3000/hayfa-test-team/demo-marketing-site/task/m0fpt8ios36a)
Author: Hayfa Awshan
