### PR TITLE
Update Contact Address to New Location

### DIFF
--- a/pages/contact.tsx
+++ b/pages/contact.tsx
@@ -76,10 +76,8 @@ export default function Contact() {
         </div>
         <div>
           <h2 className="text-2xl font-semibold mb-4">Visit Us</h2>
-          <p className="mb-2">TechCorp Headquarters</p>
-          <p className="mb-2">123 Innovation Drive</p>
-          <p className="mb-2">Silicon Valley, CA 94000</p>
-          <p className="mb-4">United States</p>
+          <p className="mb-2">123 testing</p>
+          <p className="mb-4">LONDON UK</p>
           <h2 className="text-2xl font-semibold mb-4">Contact Information</h2>
           <p className="mb-2">Phone: +1 (555) 123-4567</p>
           <p className="mb-4">Email: info@techcorp.com</p>


### PR DESCRIPTION
This pull request updates the address displayed on the Contact page. The previous address of 'TechCorp Headquarters, 123 Innovation Drive, Silicon Valley, CA 94000, United States' has been replaced with the new address '123 testing, LONDON UK'. This change reflects our company relocation and provides accurate contact information for visitors.

---

> This pull request was co-created with Cosine Genie

Original Task: [demo-marketing-site/oe5igv31t8cj](http://localhost:3000/kxgk0rl0990j/demo-marketing-site/task/oe5igv31t8cj)
Author: Hayfa Awshan
