### PR TITLE
Add FizzBuzz Function to Utils

### DIFF
--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -4,3 +4,27 @@ import { twMerge } from "tailwind-merge"
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
 }
+
+/**
+ * Returns the FizzBuzz sequence as an array of strings from 1 to n.
+ * - Multiples of 3: "Fizz"
+ * - Multiples of 5: "Buzz"
+ * - Multiples of both 3 and 5: "FizzBuzz"
+ * - Otherwise: the number as a string
+ * @param n The maximum number of the sequence
+ */
+export function fizzBuzz(n: number): string[] {
+  const result: string[] = [];
+  for (let i = 1; i <= n; i++) {
+    if (i % 15 === 0) {
+      result.push("FizzBuzz");
+    } else if (i % 3 === 0) {
+      result.push("Fizz");
+    } else if (i % 5 === 0) {
+      result.push("Buzz");
+    } else {
+      result.push(i.toString());
+    }
+  }
+  return result;
+}


### PR DESCRIPTION
This pull request introduces a new `fizzBuzz` function to the `lib/utils.ts` file. The function generates the FizzBuzz sequence up to a given number `n`, returning an array of strings. It follows these rules: it outputs 'Fizz' for multiples of 3, 'Buzz' for multiples of 5, and 'FizzBuzz' for multiples of both. For all other numbers, it returns the number as a string. This addition enhances our utility library by providing a commonly used programming challenge solution.

---

> This pull request was co-created with Cosine Genie

Original Task: [demo-marketing-site/s292dy00aagd](http://localhost:3000/kxgk0rl0990j/demo-marketing-site/task/s292dy00aagd)
Author: Hayfa Awshan
