### PR TITLE
Add FizzBuzz Function to Utils

### DIFF
--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -1,6 +1,28 @@
 import { clsx, type ClassValue } from "clsx"
 import { twMerge } from "tailwind-merge"
 
+/**
+ * Returns an array representing the FizzBuzz sequence from 1 to n.
+ * For multiples of 3, returns "Fizz"; for multiples of 5, returns "Buzz";
+ * for multiples of both, returns "FizzBuzz"; otherwise, returns the number as a string.
+ * @param n The upper limit of the sequence (inclusive)
+ */
+export function fizzBuzz(n: number): string[] {
+  const result: string[] = [];
+  for (let i = 1; i <= n; i++) {
+    if (i % 15 === 0) {
+      result.push("FizzBuzz");
+    } else if (i % 3 === 0) {
+      result.push("Fizz");
+    } else if (i % 5 === 0) {
+      result.push("Buzz");
+    } else {
+      result.push(i.toString());
+    }
+  }
+  return result;
+}
+
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
 }


### PR DESCRIPTION
This pull request introduces a new `fizzBuzz` function in `lib/utils.ts`, which generates the FizzBuzz sequence from 1 to a given upper limit, `n`. The function returns an array where each element is either 'Fizz', 'Buzz', 'FizzBuzz', or the number itself, depending on whether the number is a multiple of 3, 5, or both. This resolves the requirement for a FizzBuzz implementation as specified in the task.

---

> This pull request was co-created with Cosine Genie

Original Task: [demo-marketing-site/ko906c8dzys7](http://localhost:3000/kxgk0rl0990j/demo-marketing-site/task/ko906c8dzys7)
Author: Hayfa Awshan
