### PR TITLE
Add FizzBuzz Function to Utils

### DIFF
--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -4,3 +4,26 @@ import { twMerge } from "tailwind-merge"
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
 }
+
+/**
+ * Returns the FizzBuzz sequence up to n.
+ * For multiples of 3 returns "Fizz", for multiples of 5 returns "Buzz",
+ * and for multiples of both 3 and 5 returns "FizzBuzz". Otherwise returns the number as a string.
+ * @param n The upper limit of the FizzBuzz sequence (inclusive)
+ * @returns Array of strings representing the FizzBuzz sequence
+ */
+export function fizzBuzz(n: number): string[] {
+  const result: string[] = [];
+  for (let i = 1; i <= n; i++) {
+    if (i % 15 === 0) {
+      result.push("FizzBuzz");
+    } else if (i % 3 === 0) {
+      result.push("Fizz");
+    } else if (i % 5 === 0) {
+      result.push("Buzz");
+    } else {
+      result.push(i.toString());
+    }
+  }
+  return result;
+}


### PR DESCRIPTION
This pull request introduces a new function `fizzBuzz` in `lib/utils.ts`, which generates the FizzBuzz sequence up to a given number `n`. The function returns an array of strings where:
- Multiples of 3 are replaced with "Fizz"
- Multiples of 5 are replaced with "Buzz"
- Multiples of both 3 and 5 are replaced with "FizzBuzz"
- All other numbers are represented as strings.

This implementation provides a straightforward approach to generating the FizzBuzz sequence and will be useful for various applications.

---

> This pull request was co-created with Cosine Genie

Original Task: [demo-marketing-site/lk0x46c0bhie](http://localhost:3000/kxgk0rl0990j/demo-marketing-site/task/lk0x46c0bhie)
Author: Hayfa Awshan
