### PR TITLE
Add FizzBuzz Function to Utilities

### DIFF
--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -1,6 +1,27 @@
 import { clsx, type ClassValue } from "clsx"
 import { twMerge } from "tailwind-merge"
 
+/**
+ * Returns an array with the FizzBuzz sequence up to n.
+ * For multiples of 3, returns "Fizz"; for multiples of 5, "Buzz";
+ * for multiples of both 3 and 5, returns "FizzBuzz"; otherwise returns the number.
+ */
+export function fizzBuzz(n: number): (string | number)[] {
+  const result: (string | number)[] = [];
+  for (let i = 1; i <= n; i++) {
+    if (i % 15 === 0) {
+      result.push("FizzBuzz");
+    } else if (i % 3 === 0) {
+      result.push("Fizz");
+    } else if (i % 5 === 0) {
+      result.push("Buzz");
+    } else {
+      result.push(i);
+    }
+  }
+  return result;
+}
+
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
 }


### PR DESCRIPTION
This PR introduces a new `fizzBuzz` function in `lib/utils.ts`. The function generates the FizzBuzz sequence up to a given number `n`. For multiples of 3, it returns "Fizz"; for multiples of 5, "Buzz"; for multiples of both, "FizzBuzz"; and for all other numbers, it returns the number itself. This implementation provides a simple and efficient way to produce the FizzBuzz pattern, addressing the request for this functionality.

---

> This pull request was co-created with Cosine Genie

Original Task: [demo-marketing-site/5xypwqxytq52](http://localhost:3000/kxgk0rl0990j/demo-marketing-site/task/5xypwqxytq52)
Author: Hayfa Awshan
