### PR TITLE
Add FizzBuzz utility function

### DIFF
--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -1,6 +1,27 @@
 import { clsx, type ClassValue } from "clsx"
 import { twMerge } from "tailwind-merge"
 
+/**
+ * Utility to merge class names with Tailwind and clsx.
+ */
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
+}
+
+/**
+ * Returns the Fizz Buzz sequence up to the specified number.
+ * Multiples of 3 become "Fizz", multiples of 5 become "Buzz",
+ * multiples of both become "FizzBuzz", otherwise the number itself.
+ * @param n The length of the Fizz Buzz sequence.
+ * @returns An array of strings or numbers representing the sequence.
+ */
+export function fizzBuzz(n: number): (string | number)[] {
+  const result: (string | number)[] = [];
+  for (let i = 1; i <= n; i++) {
+    if (i % 15 === 0) result.push("FizzBuzz");
+    else if (i % 3 === 0) result.push("Fizz");
+    else if (i % 5 === 0) result.push("Buzz");
+    else result.push(i);
+  }
+  return result;
 }


### PR DESCRIPTION
This pull request introduces a new utility function `fizzBuzz` to the `lib/utils.ts` file. The `fizzBuzz` function generates a sequence of numbers and replaces certain multiples with the respective terms:

- Multiples of 3 are replaced with "Fizz"
- Multiples of 5 are replaced with "Buzz"
- Multiples of both 3 and 5 are replaced with "FizzBuzz"

The function takes a single argument, `n`, which defines the length of the FizzBuzz sequence to return. This enhancement adds a useful utility that can be leveraged in our applications for generating FizzBuzz outputs.

---

> This pull request was co-created with Cosine Genie

Original Task: [demo-marketing-site/dw5x4ng1y56k](http://localhost:3000/kxgk0rl0990j/demo-marketing-site/task/dw5x4ng1y56k)
Author: Hayfa Awshan
